### PR TITLE
Feature/fbf accounts

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -6,6 +6,20 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('register');
+
+  this.route('login', function() {
+    this.route('identity-provider');
+    this.route('email');
+  });
+
+  this.route('auth', function() {
+    this.route('external', { path: '/:identity_provider_id' });
+    this.route('callback');
+  });
+
+  this.route('logout');
+
   this.route('index', {path:'/'}, function() {
     this.route('mygoals');
     this.route('trending');

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import ApplicationRouteMixin from 'feedbackfruits-accounts/mixins/application-route-mixin';
+
+const { Route, inject: { service } } = Ember;
+
+export default Route.extend(ApplicationRouteMixin, {
+  session: service(),
+
+  title(tokens) {
+    tokens = Ember.makeArray(tokens);
+    tokens.push('FeedbackFruits');
+    let title = tokens.join(' - ');
+    // if (this.get('session.user.unread_notifications.length') > 0) {
+    //   title = `(${this.get('session.user.unread_notifications.length')}) ${title}`;
+    // }
+    return title;
+  }
+});

--- a/app/routes/auth/callback.js
+++ b/app/routes/auth/callback.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import CallbackRouteMixin from 'feedbackfruits-accounts/mixins/callback-route-mixin';
+
+const { Route } = Ember;
+
+export default Route.extend(CallbackRouteMixin);

--- a/app/routes/index/index.js
+++ b/app/routes/index/index.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  beforeModel() {
+  redirect() {
     this.transitionTo('index.mygoals');
   }
 });

--- a/app/routes/index/mygoals.js
+++ b/app/routes/index/mygoals.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import AuthenticatedRouteMixin from 'feedbackfruits-accounts/mixins/authenticated-route-mixin';
 
 var testGoals = [{
   id:1,
@@ -47,7 +48,7 @@ var testGoals = [{
   hbe:67
 }];
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
   model(){
     return testGoals;
   }

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import LoginRouteMixin from 'feedbackfruits-accounts/mixins/login-route-mixin';
+
+const { Route } = Ember;
+
+export default Route.extend(LoginRouteMixin);

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import LogoutRouteMixin from 'feedbackfruits-accounts/mixins/logout-route-mixin';
+
+const { Route } = Ember;
+
+export default Route.extend(LogoutRouteMixin);

--- a/app/routes/register.js
+++ b/app/routes/register.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import RegistrationRouteMixin from 'feedbackfruits-accounts/mixins/registration-route-mixin';
+
+const { Route } = Ember;
+
+export default Route.extend(RegistrationRouteMixin);

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -1,0 +1,18 @@
+<div class="fbf-center-container">
+  {{#fbf-text center=true light=true}}
+		Log in with your GitHub account.
+	{{/fbf-text}}
+</div>
+<div class="fbf-login-card-grid">
+  {{#each model as |idp i|}}
+    {{component 'feedbackfruits-accounts@login-identity-provider-card' model=idp}}
+  {{/each}}
+</div>
+<div class="fbf-center-container">
+  {{#fbf-text center=true light=true}}
+		Or log in with you FeedbackFruits account:
+	{{/fbf-text}}
+</div>
+<div class="fbf-btn--center-container">
+  {{component 'feedbackfruits-accounts@login-email-card'}}
+</div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,11 +1,59 @@
 /* jshint node: true */
 
+var defaults = {
+  API_HOST: 'http://localhost.feedbackfruits.com:3000',
+  ACCOUNTS_HOST: 'http://localhost.feedbackfruits.com:3001',
+  ADMIN_HOST: 'http://localhost.feedbackfruits.com:3000/admin',
+  APPSIGNAL_ENABLED: false,
+
+  production: {
+    API_HOST: 'https://bepstore-api.feedbackfruits.com',
+    ACCOUNTS_HOST: 'https://accounts.feedbackfruits.com',
+    ADMIN_HOST: 'https://bepstore-admin.feedbackfruits.com',
+    APPSIGNAL_ENABLED: true
+  },
+
+  staging: {
+    API_HOST: 'https://staging-bepstore-api.feedbackfruits.com',
+    ACCOUNTS_HOST: 'https://staging-accounts.feedbackfruits.com',
+    ADMIN_HOST: 'https://staging-bepstore-admin.feedbackfruits.com',
+    APPSIGNAL_ENABLED: true
+  }
+};
+
 module.exports = function(environment) {
+  function getEnv(key) {
+    var envVar = (environment && process.env[environment.toUpperCase() + '_' + key]) || process.env[key];
+    var defaultVar = (environment && defaults[environment] && defaults[environment][key]) || defaults[key];
+    return envVar || defaultVar;
+  }
+
   var ENV = {
     modulePrefix: 'bepstore',
     environment: environment,
     baseURL: '/',
     locationType: 'auto',
+
+    // TODO: Use non-feedbackfruits client
+    clientId: "FeedbackFruits",
+    // clientId: "BEP Store",
+    clientSecret: getEnv('CLIENT_SECRET'),
+
+    host: getEnv('API_HOST'),
+    namespace: 'v1',
+
+    accounts: {
+      host: getEnv('ACCOUNTS_HOST')
+    },
+
+    admin: {
+      host: getEnv('ADMIN_HOST')
+    },
+
+    'ember-simple-auth': {
+      authenticationRoute: 'login'
+    },
+
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,12 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
+    dotEnv: {
+      clientAllowedKeys: [
+        'API_HOST',
+        'ACCOUNTS_HOST'
+      ]
+    },
     sassOptions: {
       extension: 'sass',
       includePaths: [

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
     "ember-cli-deploy-revision-data": "0.2.3",
     "ember-cli-deploy-s3": "0.3.0",
     "ember-cli-deploy-s3-index": "0.4.0",
+    "ember-cli-dotenv": "1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-mocha": "^0.10.1",
+    "ember-cli-moment-shim": "1.2.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sass": "^5.3.1",
     "ember-cli-sri": "^2.1.0",
@@ -50,7 +52,10 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-material-lite": "0.2.2",
+    "ember-moment": "6.1.0",
     "ember-resolver": "^2.0.3",
+    "ember-simple-auth": "1.1.0",
+    "feedbackfruits-accounts": "feedbackfruits/feedbackfruits-ui-accounts",
     "feedbackfruits-styles": "feedbackfruits/feedbackfruits-ui-styles",
     "loader.js": "^4.0.1"
   }

--- a/tests/unit/routes/index/index-test.js
+++ b/tests/unit/routes/index/index-test.js
@@ -6,7 +6,7 @@ import {
 } from 'ember-mocha';
 
 describeModule(
-  'route:index',
+  'route:index/index',
   'IndexRoute',
   {
     // Specify the other units that are required for this test.


### PR DESCRIPTION
This PR adds `feedbackfruits-ui-accounts`, as well as the appropriate routes to handle registering, logging in and out and linked external accounts. At the moment, only the `/mygoals` route requires being logged in, since logging in doesn't work perfectly yet due to the accounts service not anticipating different clients than the FeedbackFruits platform. This is outside of the scope of this PR and will be fixed in the near future.

Furthermore, the `login.hbs` template renders the different options for logging in, which at the moment are GitHub and email/password. However, for the same reasons as mentioned above, this doesn't work yet since the identity providers are scoped under the client, which for the moment is still 'FeedbackFruits', which doesn't offer authentication with GitHub (yet).

To summarize, this PR adds all the necessary building blocks.